### PR TITLE
Add pandas to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ scikit-learn
 pillow
 tqdm
 taichi
+pandas


### PR DESCRIPTION
Running 3dgsconverter from a fresh environments raises an error about pandas:

```
(gsplat) emichel@macbookpro spz % 3dgsconverter -i /Users/emichel/Downloads/bird_shift_spark.splat -o /Users/emichel/Downloads/bird_shift_spark.spz 
Traceback (most recent call last):
  File "/Users/emichel/.local/share/mamba/envs/gsplat/bin/3dgsconverter", line 3, in <module>
    from gsconverter.main import main
  File "/Users/emichel/.local/share/mamba/envs/gsplat/lib/python3.11/site-packages/gsconverter/__init__.py", line 1, in <module>
    from .converter import Converter
  File "/Users/emichel/.local/share/mamba/envs/gsplat/lib/python3.11/site-packages/gsconverter/converter.py", line 2, in <module>
    from .formats.ply_3dgs import Ply3DGSFormat
  File "/Users/emichel/.local/share/mamba/envs/gsplat/lib/python3.11/site-packages/gsconverter/formats/__init__.py", line 3, in <module>
    from .parquet import ParquetFormat
  File "/Users/emichel/.local/share/mamba/envs/gsplat/lib/python3.11/site-packages/gsconverter/formats/parquet.py", line 2, in <module>
    import pandas as pd
ModuleNotFoundError: No module named 'pandas'
```

This PR simply adds pandas to `requirements.txt` in order to fix this.