### PR TITLE
Replace GPL-licensed plyfile with built-in MIT-licensed PLY reader/writer

### DIFF
--- a/gsconverter/formats/compressed_ply.py
+++ b/gsconverter/formats/compressed_ply.py
@@ -13,7 +13,7 @@ class CompressedPlyFormat(BaseFormat):
 
     def read(self, path: str, **kwargs) -> np.ndarray:
         debug_print(f"[DEBUG] Reading Compressed PLY file from {path}")
-        from plyfile import PlyData
+        from ..utils.ply_utils import PlyData
         plydata = PlyData.read(path)
         
         # Verify it's a compressed PLY (must have chunk element)
@@ -378,7 +378,7 @@ class CompressedPlyFormat(BaseFormat):
         return q[:, 0], q[:, 1], q[:, 2], q[:, 3]
 
     def _write_ply_file(self, path, chunk_data, vertex_data, sh_data):
-        from plyfile import PlyData, PlyElement
+        from ..utils.ply_utils import PlyData, PlyElement
         elements = [PlyElement.describe(chunk_data, 'chunk'), PlyElement.describe(vertex_data, 'vertex')]
         if sh_data is not None:
             elements.append(PlyElement.describe(sh_data, 'sh'))

--- a/gsconverter/formats/ply_3dgs.py
+++ b/gsconverter/formats/ply_3dgs.py
@@ -1,5 +1,5 @@
 import numpy as np
-from plyfile import PlyData, PlyElement
+from ..utils.ply_utils import PlyData, PlyElement
 from .base import BaseFormat
 from ..structures import GaussianStruct
 from ..utils.utility_functions import debug_print, status_print

--- a/gsconverter/formats/ply_cc.py
+++ b/gsconverter/formats/ply_cc.py
@@ -1,5 +1,5 @@
 import numpy as np
-from plyfile import PlyData, PlyElement
+from ..utils.ply_utils import PlyData, PlyElement
 from .base import BaseFormat
 from ..structures import GaussianStruct
 from ..utils.utility_functions import debug_print

--- a/gsconverter/main.py
+++ b/gsconverter/main.py
@@ -27,8 +27,8 @@ def check_source_extras(path):
     # Lightweight check for extra PLY elements
     try:
         if path.lower().endswith('.ply'):
-            from plyfile import PlyData
-            # Read header only? plyfile reads header on init but let's be safe
+            from ..utils.ply_utils import PlyData
+            # Read header only — lightweight text-based scan
             # PlyData.read parses the file. For large files this might be slow if it reads body.
             # However, standard PlyData.read reads everything. 
             # We can use a text-based scan for "element" lines that are not "vertex" or "face"?
@@ -85,7 +85,7 @@ def report_info(input_path, converter_obj=None):
                     print(f"SH Range: [{meta['min_sh']:.2f}, {meta['max_sh']:.2f}]")
         
         if converter_obj.source_format == 'compressed_ply':
-            from plyfile import PlyData
+            from ..utils.ply_utils import PlyData
             ply = PlyData.read(abs_path)
             num_chunks = len(ply['chunk'].data)
             print(f"Quantization: Chunk-based (256 splats/chunk)")
@@ -135,7 +135,7 @@ def report_info(input_path, converter_obj=None):
 
         if input_path.lower().endswith('.ply'):
             try:
-                from plyfile import PlyData
+                from ..utils.ply_utils import PlyData
                 pd = PlyData.read(input_path)
                 
                 is_compressed = 'chunk' in pd
@@ -218,7 +218,7 @@ def report_info(input_path, converter_obj=None):
                             active_msg += " (Cropped/Zeroed)"
 
             except Exception as e:
-                # Handle plyfile errors gracefully
+                # Handle PLY parse errors gracefully
                 print(f"Warning: Could not parse PLY header for SH analysis: {e}")
                 pass 
         

--- a/gsconverter/utils/ply_utils.py
+++ b/gsconverter/utils/ply_utils.py
@@ -1,0 +1,207 @@
+"""
+Minimal PLY binary reader/writer.
+
+Drop-in replacement for the subset of plyfile used by gsconverter.
+Supports reading and writing binary little-endian PLY files with scalar
+properties (no list properties, no ASCII/big-endian).
+
+Licensed under the MIT License — same as the rest of gsconverter.
+"""
+
+import numpy as np
+import struct
+
+# ── type mappings ──────────────────────────────────────────────────────────
+
+_PLY_TO_NUMPY = {
+    "char": "i1", "int8": "i1",
+    "uchar": "u1", "uint8": "u1",
+    "short": "i2", "int16": "i2",
+    "ushort": "u2", "uint16": "u2",
+    "int": "i4", "int32": "i4",
+    "uint": "u4", "uint32": "u4",
+    "float": "f4", "float32": "f4",
+    "double": "f8", "float64": "f8",
+}
+
+_NUMPY_TO_PLY = {
+    "i1": "char",
+    "u1": "uchar",
+    "i2": "short",
+    "u2": "ushort",
+    "i4": "int",
+    "u4": "uint",
+    "f4": "float",
+    "f8": "double",
+}
+
+
+def _numpy_kind_to_ply(dtype: np.dtype) -> str:
+    """Map a single-field numpy dtype to its PLY type name."""
+    key = dtype.byteorder.replace("=", "<").replace("|", "") + dtype.kind + str(dtype.itemsize)
+    # Normalise to little-endian / native single-char codes
+    short = dtype.kind + str(dtype.itemsize)
+    if short in _NUMPY_TO_PLY:
+        return _NUMPY_TO_PLY[short]
+    raise ValueError(f"Unsupported numpy dtype for PLY: {dtype}")
+
+
+# ── PlyProperty ────────────────────────────────────────────────────────────
+
+class PlyProperty:
+    """Lightweight stand-in so that ``element.properties`` works."""
+
+    __slots__ = ("name",)
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def __repr__(self):
+        return f"PlyProperty({self.name!r})"
+
+
+# ── PlyElement ─────────────────────────────────────────────────────────────
+
+class PlyElement:
+    """One named element inside a PLY file (e.g. 'vertex', 'chunk')."""
+
+    __slots__ = ("name", "data", "properties")
+
+    def __init__(self, name: str, data: np.ndarray):
+        self.name = name
+        self.data = data
+        self.properties = [PlyProperty(n) for n in data.dtype.names] if data.dtype.names else []
+
+    def __len__(self):
+        return len(self.data)
+
+    def __repr__(self):
+        return f"PlyElement({self.name!r}, count={len(self.data)})"
+
+    # ── factory ────────────────────────────────────────────────────────────
+    @staticmethod
+    def describe(data: np.ndarray, name: str) -> "PlyElement":
+        """Create a *PlyElement* from a numpy structured array (mirrors plyfile API)."""
+        return PlyElement(name, data)
+
+
+# ── PlyData ────────────────────────────────────────────────────────────────
+
+class PlyData:
+    """Container for a whole PLY file (header + elements)."""
+
+    def __init__(self, elements, text=False, byte_order="<"):
+        self.elements = list(elements)
+        self.byte_order = byte_order
+        self._index = {el.name: el for el in self.elements}
+
+    # ── dict-like access ───────────────────────────────────────────────────
+    def __getitem__(self, name: str) -> PlyElement:
+        return self._index[name]
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._index
+
+    # ── read ───────────────────────────────────────────────────────────────
+    @staticmethod
+    def read(path: str) -> "PlyData":
+        with open(path, "rb") as fh:
+            header_lines, header_len = _read_header(fh)
+
+        element_specs = _parse_header(header_lines)
+
+        elements = []
+        with open(path, "rb") as fh:
+            fh.seek(header_len)
+            for name, props in element_specs:
+                count, dtype = props
+                raw = fh.read(count * dtype.itemsize)
+                if len(raw) < count * dtype.itemsize:
+                    raise ValueError(
+                        f"Unexpected EOF reading element '{name}': "
+                        f"expected {count * dtype.itemsize} bytes, got {len(raw)}"
+                    )
+                arr = np.frombuffer(raw, dtype=dtype, count=count)
+                elements.append(PlyElement(name, arr))
+
+        return PlyData(elements, byte_order="<")
+
+    # ── write ──────────────────────────────────────────────────────────────
+    def write(self, path: str) -> None:
+        lines = ["ply", "format binary_little_endian 1.0"]
+        for el in self.elements:
+            lines.append(f"element {el.name} {len(el.data)}")
+            dt = el.data.dtype
+            for field_name in dt.names:
+                ply_type = _numpy_kind_to_ply(dt[field_name])
+                lines.append(f"property {ply_type} {field_name}")
+        lines.append("end_header")
+
+        header_bytes = ("\n".join(lines) + "\n").encode("ascii")
+
+        with open(path, "wb") as fh:
+            fh.write(header_bytes)
+            for el in self.elements:
+                data = el.data
+                if data.dtype.byteorder not in ("<", "=", "|"):
+                    data = data.byteswap().newbyteorder("<")
+                fh.write(data.tobytes())
+
+
+# ── internal helpers ───────────────────────────────────────────────────────
+
+def _read_header(fh):
+    """Return (list_of_header_lines, byte_offset_of_data)."""
+    lines = []
+    while True:
+        line = fh.readline()
+        if not line:
+            raise ValueError("Unexpected EOF while reading PLY header")
+        decoded = line.decode("ascii", errors="ignore").strip()
+        lines.append(decoded)
+        if decoded == "end_header":
+            break
+    return lines, fh.tell()
+
+
+def _parse_header(lines):
+    """Parse header lines into a list of (element_name, (count, numpy_dtype))."""
+    if not lines or not lines[0].startswith("ply"):
+        raise ValueError("Not a PLY file")
+
+    fmt_line = lines[1] if len(lines) > 1 else ""
+    if "binary_little_endian" not in fmt_line:
+        raise ValueError(
+            f"Only binary_little_endian PLY is supported. Got: {fmt_line!r}"
+        )
+
+    elements = []          # [(name, (count, dtype))]
+    current_name = None
+    current_count = 0
+    current_props = []     # [(field_name, numpy_type_str)]
+
+    def _flush():
+        if current_name is not None:
+            dt = np.dtype([(n, f"<{t}") for n, t in current_props])
+            elements.append((current_name, (current_count, dt)))
+
+    for line in lines[2:]:
+        if line.startswith("element"):
+            _flush()
+            parts = line.split()
+            current_name = parts[1]
+            current_count = int(parts[2])
+            current_props = []
+        elif line.startswith("property"):
+            parts = line.split()
+            if parts[1] == "list":
+                raise ValueError("List properties are not supported")
+            ply_type = parts[1]
+            prop_name = parts[2]
+            np_type = _PLY_TO_NUMPY.get(ply_type)
+            if np_type is None:
+                raise ValueError(f"Unknown PLY type: {ply_type!r}")
+            current_props.append((prop_name, np_type))
+
+    _flush()
+    return elements

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 scikit-learn
-plyfile
 numpy
 scipy
 scikit-learn


### PR DESCRIPTION
Generated by Opus 4.6 with high effort

plyfile is licensed under GPLv3, which is incompatible with this project's MIT license. The combined work cannot legally be distributed under MIT as long as it depends on a GPL library.

This commit introduces a minimal PLY binary reader/writer (gsconverter/utils/ply_utils.py) that covers the exact subset of plyfile API used by gsconverter: PlyData.read(), PlyData.write(), PlyElement.describe(), element access by name, and property introspection.

Only binary little-endian PLY with scalar properties is supported, which is all that gsconverter uses. No list properties, ASCII, or big-endian support is needed.

Changes:
- Add gsconverter/utils/ply_utils.py (MIT, ~160 lines)
- Replace all `from plyfile import ...` with `from ..utils.ply_utils import ...`
- Remove plyfile from requirements.txt